### PR TITLE
WebKit support for nightly builds

### DIFF
--- a/SafariOmnibar/SafariOmnibar-Info.plist
+++ b/SafariOmnibar/SafariOmnibar-Info.plist
@@ -36,6 +36,10 @@
 			<key>MinBundleVersion</key>
 			<string>6533</string>
 		</dict>
+		<dict>
+			<key>BundleIdentifier</key>
+			<string>org.webkit.nightly.WebKit</string>
+		</dict>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Added Support for WebKit nightly builds. Min/MaxBundleVersion left out purposefully to account for nightly version changes.
