### PR TITLE
Allow domains without a TLD to resolve

### DIFF
--- a/SafariOmnibar/SafariOmnibar.m
+++ b/SafariOmnibar/SafariOmnibar.m
@@ -43,9 +43,10 @@ NSString * const kOmnibarSearchProviders = @"SafariOmnibar_SearchProviders";
                 url = [NSURL URLWithString:[NSString stringWithFormat:@"http://%@", location]];
             }
         }
-        if (!url || (![url.host isEqualToString:@"about"] && ![NSHost hostWithName:url.host].address))
+        if ((!url || (![url.host isEqualToString:@"about"] && ![NSHost hostWithName:url.host].address))
+            && ![NSHost hostWithName:location].address)
         {
-            // When location can't be parsed as URL or URL's host part can't be resolved, perform a search using the default search provider
+            // When location can't be parsed as URL or URL's host part can't be resolved, perform a search using the default search provider, and the string itself isn't a hostname
             searchURLTemplate = [[plugin defaultSearchProvider] objectForKey:@"SearchURLTemplate"];
         }
     }

--- a/SafariOmnibar/SafariOmnibar.m
+++ b/SafariOmnibar/SafariOmnibar.m
@@ -46,7 +46,7 @@ NSString * const kOmnibarSearchProviders = @"SafariOmnibar_SearchProviders";
         if ((!url || (![url.host isEqualToString:@"about"] && ![NSHost hostWithName:url.host].address))
             && ![NSHost hostWithName:location].address)
         {
-            // When location can't be parsed as URL or URL's host part can't be resolved, perform a search using the default search provider, and the string itself isn't a hostname
+            // When location can't be parsed as URL or URL's host part can't be resolved, and the string itself isn't a hostname, perform a search using the default search provider
             searchURLTemplate = [[plugin defaultSearchProvider] objectForKey:@"SearchURLTemplate"];
         }
     }


### PR DESCRIPTION
Domains without a TLD, like "localhost" currently get turned into searches.  This will allows them to be correctly be resolved.
