### PR TITLE
Corrected required SIMBL version

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Requirement
 ===========
 
 - Safari 5.0 (Snow Leopard) or 5.1 (Lion)
-- [SIMBL](http://www.culater.net/software/SIMBL/SIMBL.php) 1.9.9 (packaged with the installer)
+- [SIMBL](http://www.culater.net/software/SIMBL/SIMBL.php) 0.9.9 (packaged with the installer)
 
 Installation
 ============


### PR DESCRIPTION
Hello Olivier,

the readme file states that SafariOmnibar requires SIMBL 1.9.9. I strongly suspect this is a typo and should be 0.9.9.

Cheers, Stefan
