### PR TITLE
Add DuckDuckGo to application defaults for search providers

### DIFF
--- a/SafariOmnibar/SearchProviders.plist
+++ b/SafariOmnibar/SearchProviders.plist
@@ -26,6 +26,16 @@
 		</dict>
 		<dict>
 			<key>Name</key>
+			<string>DuckDuckGo</string>
+			<key>Keyword</key>
+			<string>ddg</string>
+			<key>Default</key>
+			<false/>
+			<key>SearchURLTemplate</key>
+			<string>https://duckduckgo.com/?q={searchTerms}&amp;t=safariomnibar</string>
+		</dict>
+		<dict>
+			<key>Name</key>
 			<string>Wikipedia</string>
 			<key>Keyword</key>
 			<string>w</string>


### PR DESCRIPTION
This pull adds the search engine [DuckDuckGo](http://ddg.gg) to the application defaults for search providers.
